### PR TITLE
Improve Playwright browser cache key strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,16 @@ jobs:
           path: node_modules
           key: deps-${{ hashFiles('bun.lock') }}
 
+      - name: Get Playwright version
+        id: pw-version
+        run: echo "version=$(bunx playwright --version)" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ hashFiles('bun.lock') }}
+          key: playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
 
       - name: Install Playwright browsers
         if: steps.cache-playwright.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
Updated the CI workflow to use a more reliable cache key strategy for Playwright browsers that accounts for both the OS and Playwright version, rather than relying solely on the dependency lockfile.

## Key Changes
- Added a new step to extract the installed Playwright version using `bunx playwright --version`
- Modified the Playwright browser cache key from `playwright-${{ hashFiles('bun.lock') }}` to `playwright-${{ runner.os }}-${{ steps.pw-version.outputs.version }}`

## Implementation Details
The previous cache key strategy was based on the lockfile hash, which could lead to cache misses when the lockfile changes for unrelated reasons. The new approach:
- Explicitly captures the Playwright version being used
- Includes the runner OS to ensure OS-specific browser binaries aren't shared across different platforms
- Provides more granular cache invalidation that only occurs when the Playwright version actually changes

This improves CI performance by reducing unnecessary cache invalidations while ensuring correct browser binaries are used across different environments.

https://claude.ai/code/session_01JWhoBdHHbehu8D1KhS69re