### PR TITLE
Refactor overlay path generation to use manifest entries

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -10,7 +10,7 @@ import { formatPostAsBat } from '../utils/cat'
 import { calculateStats, getTopTags } from '../utils/stats'
 import { findClosestMatch } from '../utils/fuzzy'
 import { processImagesForTerminal } from '../utils/image'
-import { overlayPath, fileOverlayPath } from '../overlays'
+import { overlayPath, entryOverlayPath } from '../overlays'
 import * as vfs from '../vfs'
 import type { FsNode } from '../vfs'
 import type { Command } from './types'
@@ -472,8 +472,7 @@ export const commands: Command[] = [
       function walk(n: FsNode, prefix: string, isLast: boolean) {
         const connector = isLast ? '\u2514\u2500\u2500 ' : '\u251c\u2500\u2500 '
         const displayName = `${ansi.brightGreen}${n.name}${ansi.reset}`
-        const overlayLink =
-          n.entry && fileOverlayPath(n.name, { slug: n.entry.slug })
+        const overlayLink = n.entry && entryOverlayPath(n.entry)
         const name =
           n.type === 'dir'
             ? `${ansi.brightBlue}${n.name}/${ansi.reset}`

--- a/src/components/Terminal/Terminal.tsx
+++ b/src/components/Terminal/Terminal.tsx
@@ -15,6 +15,7 @@ import * as vfs from '../../vfs'
 import {
   getOverlayComponent,
   matchOverlayRoute,
+  entryOverlayPath,
   type OverlayState,
 } from '../../overlays'
 import './Terminal.css'
@@ -33,7 +34,7 @@ function getWelcomeBanner(): string {
       .slice(0, 3)
       .map(
         (entry, idx) =>
-          `    ${ansi.dim}${idx + 1}. ${formatLink(`#/post/${entry.slug}`, `${ansi.brightCyan}${entry.slug}${ansi.reset}`)} ${ansi.dim}(${entry.meta.date}) - ${entry.meta.title}${ansi.reset}`,
+          `    ${ansi.dim}${idx + 1}. ${formatLink(`#${entryOverlayPath(entry)}`, `${ansi.brightCyan}${entry.slug}${ansi.reset}`)} ${ansi.dim}(${entry.meta.date}) - ${entry.meta.title}${ansi.reset}`,
       ),
     '',
     `  ${ansi.dim}Type ${ansi.reset}${ansi.brightGreen}help${ansi.reset}${ansi.dim} to get started.${ansi.reset}`,

--- a/src/overlays/index.ts
+++ b/src/overlays/index.ts
@@ -1,4 +1,5 @@
 import { lazy, type ComponentType } from 'react'
+import type { VfsManifestEntry } from '../../vite-plugin-vfs-manifest'
 import { pager } from './pager'
 
 export interface OverlayProps {
@@ -28,16 +29,12 @@ const overlays: Record<string, OverlayEntry> = {
 
 export const overlayRoutes = Object.values(overlays).map((o) => o.route)
 
-/** Return an overlay path for a file, or null if no overlay handles its extension. */
-export function fileOverlayPath(
-  filename: string,
-  params: Record<string, string>,
-): string | null {
-  const dot = filename.lastIndexOf('.')
-  if (dot === -1) return null
-  const ext = filename.slice(dot)
-  for (const [name, entry] of Object.entries(overlays)) {
-    if (entry.extensions?.includes(ext)) return overlayPath(name, params)
+/** Return an overlay path for a manifest entry, or null if no overlay handles it. */
+export function entryOverlayPath(entry: VfsManifestEntry): string | null {
+  const ext = entry.path.slice(entry.path.lastIndexOf('.'))
+  for (const [name, o] of Object.entries(overlays)) {
+    if (o.extensions?.includes(ext))
+      return overlayPath(name, { slug: entry.slug })
   }
   return null
 }

--- a/src/overlays/pager.ts
+++ b/src/overlays/pager.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react'
 import type { OverlayEntry, OverlayProps } from './index'
-import { findBySlug, readFile, HOME } from '../vfs'
+import { findBySlug, readBySlug } from '../vfs'
 
 export const pager: OverlayEntry = {
   route: '/post/:slug',
@@ -11,14 +11,13 @@ export const pager: OverlayEntry = {
       default: m.Pager as unknown as ComponentType<OverlayProps>,
     })),
   resolve: (params) => {
-    const entry = findBySlug(params.slug)
-    if (!entry) return null
+    if (!findBySlug(params.slug)) return null
     return {
       loadProps: async () => {
-        const post = await readFile(HOME + entry.path)
+        const post = await readBySlug(params.slug)
         return post ? { post } : null
       },
-      displayArg: entry.slug,
+      displayArg: params.slug,
     }
   },
 }

--- a/src/vfs.ts
+++ b/src/vfs.ts
@@ -164,6 +164,13 @@ export function findBySlug(slug: string): VfsManifestEntry | undefined {
   return manifest.find((e) => e.slug === slug)
 }
 
+/** Load a post by slug. Combines findBySlug + readFile. */
+export async function readBySlug(slug: string): Promise<Post | null> {
+  const entry = findBySlug(slug)
+  if (!entry) return null
+  return readFile(HOME + entry.path)
+}
+
 /** All manifest entries sorted by date descending (for welcome banner, etc). */
 export function allEntries(): VfsManifestEntry[] {
   return [...manifest].sort(


### PR DESCRIPTION
## Summary
Refactored the overlay path generation system to work directly with VFS manifest entries instead of filenames and parameter objects. This simplifies the API and makes the code more type-safe by leveraging the manifest entry structure.

## Key Changes
- **Renamed `fileOverlayPath` to `entryOverlayPath`**: Changed the function signature to accept a `VfsManifestEntry` directly instead of a filename and params object. The function now extracts the extension from `entry.path` and automatically uses `entry.slug` for the overlay path.
- **Added `readBySlug` helper**: Created a new utility function in `vfs.ts` that combines `findBySlug` and `readFile` operations, reducing boilerplate in consumers.
- **Simplified pager overlay resolution**: Updated the pager overlay to use the new `readBySlug` function, eliminating redundant entry lookups and file path construction.
- **Updated all call sites**: Modified `registry.ts` and `Terminal.tsx` to use the new `entryOverlayPath` API with manifest entries instead of constructing parameters manually.
- **Improved welcome banner links**: Changed hardcoded post links to use `entryOverlayPath` for consistency and maintainability.

## Implementation Details
- The refactoring maintains backward compatibility in functionality while improving the internal API
- By accepting manifest entries directly, the function eliminates the need for callers to manually construct parameter objects
- The `readBySlug` helper reduces code duplication and makes the intent clearer at call sites

https://claude.ai/code/session_01WukSHa4s8m4873EFTzf2qE