### PR TITLE
Enable auto-merge and merge queue support

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -26,6 +26,7 @@ repository:
   allow_squash_merge: true
   allow_merge_commit: false
   allow_rebase_merge: true
+  allow_auto_merge: true
   delete_branch_on_merge: true
 
   # Security
@@ -58,6 +59,10 @@ branches:
 
       # Enforce linear history (no merge commits on main)
       required_linear_history: true
+
+      # Merge queue — not supported by the repository-settings app or
+      # the REST branch protection API. Enable "Require merge queue" in
+      # the GitHub UI under Settings > Branches > main protection rule.
 
       # No force pushes or branch deletion
       restrictions: null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   pull_request:
     branches: ['main']
+  merge_group:
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
This PR enables auto-merge functionality and adds support for GitHub's merge queue feature to improve the merge workflow and CI/CD pipeline reliability.

## Key Changes
- **Repository Settings**: Enabled `allow_auto_merge` to permit automatic merging of pull requests when all requirements are met
- **CI Workflow**: Added `merge_group` trigger to support merge queue operations, allowing CI to run on queued merge requests
- **Concurrency Handling**: Updated concurrency group expression to handle both pull request and merge queue events using `github.event.pull_request.number || github.ref`
- **Documentation**: Added clarifying comment about merge queue configuration limitations in the branch protection settings

## Implementation Details
The merge queue feature requires manual enablement in the GitHub UI (Settings > Branches > main protection rule) as it's not yet supported by the repository-settings app or REST API. The CI workflow now properly handles both traditional pull request events and merge queue events through the updated concurrency logic, ensuring proper cancellation of in-progress runs across both scenarios.

https://claude.ai/code/session_01LB2vz1D3YacGyGJ1BePdPr