### PR TITLE
Add sidecar metadata system for non-markdown content

### DIFF
--- a/src/commands/registry.ts
+++ b/src/commands/registry.ts
@@ -326,28 +326,40 @@ export const commands: Command[] = [
         return
       }
 
-      const post = await vfs.readFile(resolved)
-      if (!post) {
+      const content = await vfs.readFile(resolved)
+      if (!content) {
         terminal.writeln('')
         terminal.writeln(formatError(`cat: '${args[0]}': Not a readable file`))
         terminal.writeln('')
         return
       }
 
-      if (Object.keys(post.images).length > 0) {
+      if (content.type !== 'markdown') {
+        terminal.writeln('')
+        terminal.writeln(
+          `  ${ansi.brightWhite}${content.title}${ansi.reset} ${ansi.dim}(${content.extension})${ansi.reset}`,
+        )
+        terminal.writeln(
+          formatDim(`  Binary file — use less to view in an overlay`),
+        )
+        terminal.writeln('')
+        return
+      }
+
+      if (Object.keys(content.images).length > 0) {
         const processedContent = await processImagesForTerminal(
-          post.content,
-          post.images,
+          content.content,
+          content.images,
           terminal.cols,
         )
         terminal.write(
           formatPostAsBat(
-            { ...post, content: processedContent },
+            { ...content, content: processedContent },
             { cols: terminal.cols },
           ),
         )
       } else {
-        terminal.write(formatPostAsBat(post, { cols: terminal.cols }))
+        terminal.write(formatPostAsBat(content, { cols: terminal.cols }))
       }
     },
   },
@@ -395,16 +407,27 @@ export const commands: Command[] = [
         return
       }
 
-      const post = await vfs.readFile(resolved)
-      if (!post) {
+      const content = await vfs.readFile(resolved)
+      if (!content) {
         terminal.writeln('')
         terminal.writeln(formatError(`less: '${args[0]}': Not a readable file`))
         terminal.writeln('')
         return
       }
 
-      navigate(overlayPath('pager', { slug: post.slug }))
-      if (openOverlay) return openOverlay('pager', { post })
+      if (content.type !== 'markdown') {
+        terminal.writeln('')
+        terminal.writeln(
+          formatError(
+            `less: '${args[0]}': No overlay registered for ${content.extension} files`,
+          ),
+        )
+        terminal.writeln('')
+        return
+      }
+
+      navigate(overlayPath('pager', { slug: content.slug }))
+      if (openOverlay) return openOverlay('pager', { post: content })
     },
   },
   {

--- a/src/components/Pager/Pager.tsx
+++ b/src/components/Pager/Pager.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
-import type { Post } from '../../data/types'
+import type { MarkdownContent } from '../../data/types'
 import { renderMarkdown } from '../../utils/markdown'
 import './Pager.css'
 
 interface PagerProps {
-  post: Post
+  post: MarkdownContent
   onClose: () => void
 }
 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -1,9 +1,21 @@
-export interface Post {
+interface ContentBase {
   slug: string
   title: string
   date: string
   tags: string[]
   excerpt: string
-  content: string
+}
+
+export interface MarkdownContent extends ContentBase {
+  type: 'markdown'
+  content: string // rendered markdown body
   images: Record<string, string> // filename → Vite-resolved URL
 }
+
+export interface AssetContent extends ContentBase {
+  type: 'asset'
+  src: string // Vite-resolved URL
+  extension: string // '.png', '.pdf', etc.
+}
+
+export type Content = MarkdownContent | AssetContent

--- a/src/overlays/pager.ts
+++ b/src/overlays/pager.ts
@@ -14,8 +14,9 @@ export const pager: OverlayEntry = {
     if (!findBySlug(params.slug)) return null
     return {
       loadProps: async () => {
-        const post = await readBySlug(params.slug)
-        return post ? { post } : null
+        const content = await readBySlug(params.slug)
+        if (!content || content.type !== 'markdown') return null
+        return { post: content }
       },
       displayArg: params.slug,
     }

--- a/src/utils/cat.test.ts
+++ b/src/utils/cat.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest'
 import { ansi } from './ansi'
 import { formatPostAsBat, _internal } from './cat'
-import type { Post } from '../data/types'
+import type { MarkdownContent } from '../data/types'
 
 const {
   wrapAnsi,
@@ -299,7 +299,8 @@ describe('highlightSyntax', () => {
 // ── formatPostAsBat (integration) ──────────────────────────
 
 describe('formatPostAsBat', () => {
-  const post: Post = {
+  const post: MarkdownContent = {
+    type: 'markdown',
     slug: 'test-post',
     title: 'Test Post',
     date: '2025-01-15',
@@ -320,7 +321,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('wraps long lines within cols boundary', () => {
-    const longPost: Post = {
+    const longPost: MarkdownContent = {
       ...post,
       content:
         'This is a very long line that should be wrapped because it exceeds the column width that we have set for the terminal display output',
@@ -334,7 +335,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('renders markdown links as clickable in post content', () => {
-    const linkPost: Post = {
+    const linkPost: MarkdownContent = {
       ...post,
       content: 'Visit [Example](https://example.com) today',
     }
@@ -344,7 +345,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('does not break link syntax across wrapped lines', () => {
-    const linkPost: Post = {
+    const linkPost: MarkdownContent = {
       ...post,
       content:
         'I recommend reading [Jeff Atwood](https://twitter.com/codinghorror) for programming insights',
@@ -356,7 +357,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('wraps every line within cols boundary including lines with links', () => {
-    const linkPost: Post = {
+    const linkPost: MarkdownContent = {
       ...post,
       content:
         "Both [Let's Encrypt](https://letsencrypt.org/) and [Cloudflare](https://www.cloudflare.com/) have recently started offering free Domain Validated certificates for personal websites.",
@@ -369,7 +370,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('wraps real blog content with multiple links within cols', () => {
-    const realPost: Post = {
+    const realPost: MarkdownContent = {
       ...post,
       content:
         "While I don't expect to do any payment processing on my personal blog nor do I serve up any login page, having an SSL issued from a trusted CA will still protect readers of my blog from a [Man-in-the-middle (MITM) attack](https://wikipedia.org/wiki/Man-in-the-middle_attack). Additionally, a huge motivation for me to use SSL was that Google now uses [HTTPS as a ranking signal](https://security.googleblog.com/2014/08/https-as-ranking-signal_6.html).",
@@ -390,7 +391,7 @@ describe('formatPostAsBat', () => {
   })
 
   it('does not wrap iTerm2 image sequences', () => {
-    const imgPost: Post = {
+    const imgPost: MarkdownContent = {
       ...post,
       content:
         '\x1b]1337;File=inline=1;size=100;width=40:base64base64base64base64\x07',

--- a/src/utils/cat.ts
+++ b/src/utils/cat.ts
@@ -1,5 +1,5 @@
 import { ansi, formatLink } from './ansi'
-import type { Post } from '../data/types'
+import type { MarkdownContent } from '../data/types'
 
 /* eslint-disable no-control-regex */
 const RE_OSC8_LINK = /\x1b\]8;;([^\x07\x1b]*?)(?:\x07|\x1b\\)/g
@@ -31,7 +31,10 @@ interface BatOptions {
 /**
  * Format a post in bat-style with header and syntax highlighting
  */
-export function formatPostAsBat(post: Post, options: BatOptions = {}): string {
+export function formatPostAsBat(
+  post: MarkdownContent,
+  options: BatOptions = {},
+): string {
   const { showHeader = true, cols = 80 } = options
 
   const lines = post.content.split('\r\n')
@@ -423,7 +426,7 @@ function getTagColor(tag: string): string {
 /**
  * Get icon/symbol for post based on tags
  */
-function getPostIcon(post: Post): string {
+function getPostIcon(post: MarkdownContent): string {
   const tags = post.tags.map((t) => t.toLowerCase())
 
   if (tags.some((t) => t.includes('meta') || t.includes('intro'))) {
@@ -470,7 +473,10 @@ export interface LsOptions {
 /**
  * Format ls output in bat-style grid with enhanced features
  */
-export function formatLsOutput(posts: Post[], options: LsOptions = {}): string {
+export function formatLsOutput(
+  posts: MarkdownContent[],
+  options: LsOptions = {},
+): string {
   const { longFormat = false, showAll = false, sortBy = 'date' } = options
   const output: string[] = []
 
@@ -574,7 +580,7 @@ export function formatLsOutput(posts: Post[], options: LsOptions = {}): string {
  * Format grep search results with context
  */
 export interface GrepMatch {
-  post: Post
+  post: MarkdownContent
   lineNum: number
   line: string
   contextBefore: string[]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,10 @@ import vfsManifest from './vite-plugin-vfs-manifest'
 export default defineConfig({
   plugins: [
     react(),
-    vfsManifest({ pattern: 'posts/**/*.md' }),
+    vfsManifest({
+      pattern: 'posts/**/*.md',
+      sidecarPattern: 'posts/**/.*.meta.yaml',
+    }),
     // Gzip compression
     viteCompression({
       algorithm: 'gzip',


### PR DESCRIPTION
Replace Post type with Content discriminated union (MarkdownContent | AssetContent)
to support arbitrary file types in the VFS. Add sidecar metadata scanning
(.<filename>.meta.yaml) to the Vite manifest plugin so non-markdown files can
carry title, date, tags, and excerpt metadata without embedded frontmatter.

Key changes:
- VfsManifestEntry gains an `extension` field
- Vite plugin scans for .*.meta.yaml sidecars alongside existing .md frontmatter
- VFS readFile() returns Content union, dispatching by extension
- cat/less commands narrow the Content type before rendering
- Pager overlay and component updated to use MarkdownContent

https://claude.ai/code/session_015Q55j43a5CAhyL1RNYLTWi